### PR TITLE
multi objective support for compiling from minizinc to flatzinc

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,19 @@ to the `PATH` environment variable:
 
     export PATH=$PATH:.../emzn2fzn/src/
 
+Next, copy the contents of `std` to your shared minizinc folder
+
+  ```
+  cp std <YOUR_MINIZINC_PATH>/share/minizinc/std
+  ``` 
+
 and also export the absolute path to the the global constraints
 directory of [`OptiMathSAT`](http://optimathsat.disi.unitn.it/)
 distributed with this package (or downloaded from the official
 website):
 
     export SMT2_GLOBALS_DIR=.../emzn2fzn/smt2/
+
 
 To make these changes permanent, please consider editing the
 `~/.bashrc` file.

--- a/example/pareto.fzn
+++ b/example/pareto.fzn
@@ -1,0 +1,5 @@
+array [1..2] of int: X_INTRODUCED_2_ = [1,1];
+var 1..9: v1:: output_var:: is_defined_var;
+var 1..10: v2:: output_var;
+constraint int_lin_eq(X_INTRODUCED_2_,[v1,v2],10):: defines_var(v1);
+solve maximize v1, maximize v2;

--- a/example/pareto.mzn
+++ b/example/pareto.mzn
@@ -1,0 +1,9 @@
+include "pareto_mo.mzn";
+
+var 1..10: v1;
+var 1..10: v2;
+
+constraint v1 = 10 - v2;
+
+solve :: goals_p([maximize_p(v1), maximize_p(v2)]) satisfy;
+

--- a/src/emzn2fzn.py
+++ b/src/emzn2fzn.py
@@ -271,7 +271,7 @@ def parse_mo(fzn_file):
 
 def get_mzn2fzn_cmdline_args(mzn_file, known_args, other_args):
     """Determines the command-line arguments for the mzn2fzn call."""
-    args = ["minizinc", "-c", "--solver", "org.minizinc.mzn-fzn",  mzn_file]
+    args = ["minizinc", "-c", "--solver", "org.minizinc.mzn-fzn",  mzn_file, "--no-output-ozn"]
     if known_args.fzn is not None:
         args.append("--fzn")
         args.append(known_args.fzn)

--- a/std/pareto_mo.mzn
+++ b/std/pareto_mo.mzn
@@ -1,0 +1,22 @@
+
+% annotations to use for defining multi_objective solving
+% these are recognized by emzn2fzn
+/**
+    example:
+
+    The following minizinc snippet
+    \code
+    solve :: goals_p([maximize_p(v1), minimize_p(v2)]) satisfy;
+    \endcode
+
+    should be translated by emzn2fzn to the following flatzinc snippet:
+    \code
+    solve maximize v1, minimize v2;
+    \endcode
+*/
+
+annotation goals_p(array[int] of ann);
+annotation maximize_p(var int: x);
+annotation minimize_p(var int: x);
+annotation maximize_p(var float: x);
+annotation minimize_p(var float: x);


### PR DESCRIPTION
I did so by introducing new annotations, as specified in `pareto_mo.mzn`. See `example/pareto.mzn` for an example.

`pareto_mo.mzn` should be added as well. I added extra steps to the installation instructions how to add this to the global minizinc folder.

This PR also provides a fix for issue #1 

